### PR TITLE
Fixes typo in README code sample

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ In a Rails controller, this operation could be used as follows:
 class UsersController < ApplicationController
   def create
     result = CreateUser.new(user_params).perform
-    if operation.success?
+    if result.success?
       user = result.unwrap!
       T.reveal_type(user) # `User`
       redirect_to user


### PR DESCRIPTION
Just noticed this while reading up on the how the operations work.