### PR TITLE
Lazily evaluate log strings

### DIFF
--- a/lib/sorbet_operation/base.rb
+++ b/lib/sorbet_operation/base.rb
@@ -38,16 +38,16 @@ module SorbetOperation
     # Performs the operation and returns the result.
     sig { returns(Result[ValueType]) }
     def perform
-      logger.debug("Performing operation #{self.class.name}")
+      logger.debug { "Performing operation #{self.class.name}" }
 
       begin
         value = execute
       rescue Failure => e
-        logger.debug("Operation #{self.class.name} failed, failure = #{e.inspect}")
+        logger.debug { "Operation #{self.class.name} failed, failure = #{e.inspect}" }
 
         Result.new(false, nil, e)
       else
-        logger.debug("Operation #{self.class.name} succeeded, return value = #{value.inspect}")
+        logger.debug { "Operation #{self.class.name} succeeded, return value = #{value.inspect}" }
 
         Result.new(true, value, nil)
       end


### PR DESCRIPTION
Switch `logger.debug` statements to use blocks vs. directly interpolated
strings, which should both improve performance[^1] and prevent bugs where
objects are being inadvertently evaluated, e.g. `ActiveRecord::Relation#inspect`.

[^1]: https://guides.rubyonrails.org/debugging_rails_applications.html#impact-of-logs-on-performance
