### PR TITLE
Fix broken pages deploy

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,15 +1,15 @@
 name: Deploy Yard docs to GitHub Pages
 on:
   push:
-    branches: ['main']
+    branches: ["main"]
     paths:
-      - '.github/workflows/pages.yml'
-      - '.yardopts'
-      - 'lib/**'
-      - '**.gemspec'
-      - 'Gemfile'
-      - '**.md'
-      - '**.txt'
+      - ".github/workflows/pages.yml"
+      - ".yardopts"
+      - "lib/**"
+      - "**.gemspec"
+      - "Gemfile"
+      - "**.md"
+      - "**.txt"
     # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
@@ -20,7 +20,7 @@ permissions:
 
 # Allow one concurrent deployment
 concurrency:
-  group: 'pages'
+  group: "pages"
   cancel-in-progress: true
 
 jobs:
@@ -32,10 +32,16 @@ jobs:
     runs-on: ubuntu-latest
     name: Build and deploy YARD
     steps:
-      - uses: kachick/deploy-yard-to-pages@v1.3.0
-        id: deployment
-        # with:
-          # # default `doc` as default of `.yardopts`
-          # output-dir: 'docs'
-          # # default version is 3.2
-          # ruby-version: '3.2'
+      - name: Checkout
+        uses: actions/checkout@v4
+      - uses: ruby/setup-ruby@v1
+        with:
+          bundler-cache: true
+      - run: bundle exec yard
+        shell: bash
+      - uses: actions/configure-pages@v5
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: doc
+      - id: deployment
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
Replace archived and broken `kachick/deploy-yard-to-pages` action.

See: https://github.com/kachick/ruby-ulid/commit/a88b4c7a14fdcf119950431abc515e0b34f629e7
