### PR TITLE
Update CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,11 +3,25 @@ name: CI
 on: [push]
 
 jobs:
+  security:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: ruby/setup-ruby@v1
+        with:
+          bundler-cache: true
+
+      - name: Run bundler-audit
+        run: |
+          bundle exec bundle-audit check --update
+
   lint:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - uses: ruby/setup-ruby@v1
         with:
@@ -35,7 +49,7 @@ jobs:
           - head
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - uses: ruby/setup-ruby@v1
         with:

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -24,18 +24,32 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  deploy_yard:
-    # the deploy environment (not to be confused with env)
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: ruby/setup-ruby@v1
+        with:
+          bundler-cache: true
+
+      - name: Generate YARD documentation
+        run: |
+          bundle exec yard doc
+
+      - name: Upload pages artifact
+        id: deployment
+        uses: actions/upload-pages-artifact@v4
+        with:
+          path: doc/
+
+  deploy:
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
-    name: Build and deploy YARD
+    needs: build
     steps:
-      - uses: kachick/deploy-yard-to-pages@v1.3.0
+      - name: Deploy to GitHub Pages
         id: deployment
-        # with:
-          # # default `doc` as default of `.yardopts`
-          # output-dir: 'docs'
-          # # default version is 3.2
-          # ruby-version: '3.2'
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Release Gem
         if: contains(github.ref, 'refs/tags/v')


### PR DESCRIPTION
Update CI:
- use latest version of each action
- add `security` job to run bundler-audit
- fix the GitHub Pages deploy job
